### PR TITLE
FollowPermission: give permision to requester

### DIFF
--- a/feelslikemonday/app/src/main/java/com/example/feelslikemonday/ui/followrequest/ArraryAdapter/RequestList.java
+++ b/feelslikemonday/app/src/main/java/com/example/feelslikemonday/ui/followrequest/ArraryAdapter/RequestList.java
@@ -34,7 +34,6 @@ public class RequestList extends ArrayAdapter<String> {
     private List<String> followeeUsernames;
     private static FollowPermissionDAO DAO;
     private static FollowRequestDAO followRequestDAO;
-    private final CountDownLatch signal = new CountDownLatch(1);
 
 
     public RequestList(@NonNull Context context, ArrayList<String> users) {
@@ -77,7 +76,6 @@ public class RequestList extends ArrayAdapter<String> {
                             DAO.createOrUpdate("xiaole", followPermission, new VoidCallback() {
                                 @Override
                                 public void onCallback() {
-                                    signal.countDown();
                                 }
                             });
                         }
@@ -95,7 +93,6 @@ public class RequestList extends ArrayAdapter<String> {
                             followRequestDAO.createOrUpdate("xiaole", followRequest, new VoidCallback() {
                                 @Override
                                 public void onCallback() {
-                                    signal.countDown();
                                 }
                             });
                         }
@@ -121,13 +118,17 @@ public class RequestList extends ArrayAdapter<String> {
                             followRequestDAO.createOrUpdate("xiaole", followRequest, new VoidCallback() {
                                 @Override
                                 public void onCallback() {
-                                    signal.countDown();
                                 }
                             });
+
+                            RequestList.this.remove(user);
+
                         }
 
                     }
                 },null);
+
+
 
             }
         });

--- a/feelslikemonday/app/src/main/java/com/example/feelslikemonday/ui/followrequest/ArraryAdapter/RequestList.java
+++ b/feelslikemonday/app/src/main/java/com/example/feelslikemonday/ui/followrequest/ArraryAdapter/RequestList.java
@@ -1,28 +1,45 @@
 package com.example.feelslikemonday.ui.followrequest.ArraryAdapter;
 
 import android.content.Context;
+import android.util.Log;
+import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
+import android.widget.Button;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.example.feelslikemonday.DAO.FollowPermissionCallback;
+import com.example.feelslikemonday.DAO.FollowPermissionDAO;
+import com.example.feelslikemonday.DAO.FollowRequestCallback;
+import com.example.feelslikemonday.DAO.FollowRequestDAO;
+import com.example.feelslikemonday.DAO.VoidCallback;
 import com.example.feelslikemonday.R;
+import com.example.feelslikemonday.model.FollowPermission;
+import com.example.feelslikemonday.model.FollowRequest;
 import com.example.feelslikemonday.model.User;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
 
-public class RequestList extends ArrayAdapter<User> {
-    private ArrayList<User> users;
+public class RequestList extends ArrayAdapter<String> {
     private Context context;
+    private List<String> requesterUsernames;
+    private List<String> followeeUsernames;
+    private static FollowPermissionDAO DAO;
+    private static FollowRequestDAO followRequestDAO;
+    private final CountDownLatch signal = new CountDownLatch(1);
 
 
-    public RequestList(@NonNull Context context, ArrayList<User> users) {
+    public RequestList(@NonNull Context context, ArrayList<String> users) {
         super(context, 0, users);
-        this.users = users;
+        this.requesterUsernames = users;
         this.context = context;
     }
 
@@ -30,14 +47,93 @@ public class RequestList extends ArrayAdapter<User> {
     @Override
     public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
         //return super.getView(position, convertView, parent);
+        DAO = FollowPermissionDAO.getInstance();
+        followRequestDAO = FollowRequestDAO.getInstance();
         View view = convertView;
+
         if(view == null){
             view = LayoutInflater.from(context).inflate(R.layout.content_follow_request, parent, false);
         }
-        User user = users.get(position);
-        TextView userName = view.findViewById(R.id.username_text);
-        userName.setText(user.getUsername());
+        final String user = requesterUsernames.get(position);
 
+        TextView userName = view.findViewById(R.id.username_text);
+        userName.setText(user);
+
+        Button acceptButton = view.findViewById(R.id.request_accept_button);
+        Button rejectButton = view.findViewById(R.id.request_reject_button);
+
+        acceptButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                Log.i("testListView", "clickAcceptButton");
+
+                DAO.get("xiaole", new FollowPermissionCallback(){
+                    @Override
+                    public void onCallback(FollowPermission followPermission) {
+                        if(followPermission.getFollowerUsername().equals("xiaole")){
+                            followeeUsernames = followPermission.getFolloweeUsernames();
+                            followeeUsernames.add(user);
+
+                            DAO.createOrUpdate("xiaole", followPermission, new VoidCallback() {
+                                @Override
+                                public void onCallback() {
+                                    signal.countDown();
+                                }
+                            });
+                        }
+
+                    }
+                }, null);
+
+                followRequestDAO.get("xiaole", new FollowRequestCallback(){
+                    @Override
+                    public void onCallback(FollowRequest followRequest) {
+                        if(followRequest.getRecipientUsername().equals("xiaole")){
+                            requesterUsernames = followRequest.getRequesterUsernames();
+                            requesterUsernames.remove(user);
+
+                            followRequestDAO.createOrUpdate("xiaole", followRequest, new VoidCallback() {
+                                @Override
+                                public void onCallback() {
+                                    signal.countDown();
+                                }
+                            });
+                        }
+
+                    }
+                },null);
+
+            }
+        });
+
+        rejectButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                Log.i("testListView", "clickRejectButton");
+
+                followRequestDAO.get("xiaole", new FollowRequestCallback(){
+                    @Override
+                    public void onCallback(FollowRequest followRequest) {
+                        if(followRequest.getRecipientUsername().equals("xiaole")){
+                            requesterUsernames = followRequest.getRequesterUsernames();
+                            requesterUsernames.remove(user);
+
+                            followRequestDAO.createOrUpdate("xiaole", followRequest, new VoidCallback() {
+                                @Override
+                                public void onCallback() {
+                                    signal.countDown();
+                                }
+                            });
+                        }
+
+                    }
+                },null);
+
+            }
+        });
         return view;
+
+
+
     }
 }

--- a/feelslikemonday/app/src/main/java/com/example/feelslikemonday/ui/followrequest/FollowerRequestFragment.java
+++ b/feelslikemonday/app/src/main/java/com/example/feelslikemonday/ui/followrequest/FollowerRequestFragment.java
@@ -3,11 +3,16 @@ package com.example.feelslikemonday.ui.followrequest;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.util.Log;
+import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
+import android.widget.Button;
 import android.widget.ListView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -15,17 +20,23 @@ import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProviders;
 
+import com.example.feelslikemonday.DAO.FollowRequestCallback;
+import com.example.feelslikemonday.DAO.FollowRequestDAO;
+import com.example.feelslikemonday.DAO.VoidCallback;
 import com.example.feelslikemonday.R;
+import com.example.feelslikemonday.model.FollowRequest;
 import com.example.feelslikemonday.ui.followrequest.ArraryAdapter.RequestList;
 import com.example.feelslikemonday.model.User;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class FollowerRequestFragment extends Fragment {
     private ListView userList;
-    private ArrayAdapter<User> userAdapter;
-    private ArrayList<User> userDataList;
-    private RequestList requestList;
+    private ArrayAdapter<String> userAdapter;
+    private List<String> requesterUsernames;
+    private static FollowRequestDAO DAO;
+
 
     private FollowerRequestViewModel followerViewModel;
 
@@ -34,27 +45,47 @@ public class FollowerRequestFragment extends Fragment {
 
         followerViewModel = ViewModelProviders.of(this).get(FollowerRequestViewModel.class);
 
-        View root = inflater.inflate(R.layout.fragment_follower_request, container, false);
+        final View root = inflater.inflate(R.layout.fragment_follower_request, container, false);
+        userList = (ListView) root.findViewById(R.id.request_username_list);
 
-        userList = root.findViewById(R.id.request_username_list);
-        userDataList = new ArrayList<>();
-        //test
-        String username = "your lovely follower";
-        String pass = "test";
-        String email = "test";
-        User userA = new User(username,pass);
+        DAO = FollowRequestDAO.getInstance();
+        //TODO: PASS mySharedPreference filename
+        DAO.get("xiaole", new FollowRequestCallback(){
+            @Override
+            public void onCallback(FollowRequest followRequest) {
+                if(followRequest.getRecipientUsername().equals("xiaole")){
 
-        userDataList.add(userA);
-        userAdapter = new RequestList(getActivity(), userDataList);
-        userList.setAdapter(userAdapter);
+                    requesterUsernames = followRequest.getRequesterUsernames();
+                    userAdapter = new RequestList(getContext(), new ArrayList<String>(requesterUsernames));
+                    userList.setAdapter(userAdapter);
+                    userAdapter.notifyDataSetChanged();
+                }
+
+            }
+        }, new VoidCallback() {
+            @Override
+            public void onCallback() {
+                Toast toast = Toast.makeText(getActivity(), "User Not Exist in database(CHECK Login Activity)", Toast.LENGTH_LONG);
+                toast.setGravity(Gravity.CENTER| Gravity.CENTER_HORIZONTAL, 0, 0);
+                toast.show();
+            }
+        });
+
+        userList.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+            @Override
+            public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
+                Log.i("testListView", "click");
+                //TODO: show the detail of the requester
+            }
+        });
+
         followerViewModel.getText().observe(getViewLifecycleOwner(), new Observer<String>() {
             @Override
             public void onChanged(@Nullable String s) {
                 //do stuff here
-
-
             }
         });
+
 
 
         return root;

--- a/feelslikemonday/app/src/main/java/com/example/feelslikemonday/ui/followrequest/FollowerRequestFragment.java
+++ b/feelslikemonday/app/src/main/java/com/example/feelslikemonday/ui/followrequest/FollowerRequestFragment.java
@@ -59,6 +59,7 @@ public class FollowerRequestFragment extends Fragment {
                     userAdapter = new RequestList(getContext(), new ArrayList<String>(requesterUsernames));
                     userList.setAdapter(userAdapter);
                     userAdapter.notifyDataSetChanged();
+
                 }
 
             }

--- a/feelslikemonday/app/src/main/res/layout/content_follow_request.xml
+++ b/feelslikemonday/app/src/main/res/layout/content_follow_request.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/linearLayout"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:descendantFocusability="blocksDescendants">
 
     <TextView
         android:id="@+id/username_text"


### PR DESCRIPTION
FollowPermission functionality:
* Check the user(myself) that I have a document inside the database. In the login/Register part, the developer should create document for User, FollowRequest and FollowPermission.
* Will update the data inside the firebase.
     - If I click "Accept", my requester list will delete the name in the firebase and put the name inside the FollowPermission document.
     - If I click "Reject", my requester list will delete the name in the firebase and no more action
* Create my own FollowPermissionDAO to test this functionality.

Todo: 
* corresponding to my SharedPreference
* The ViewList in the app doesn't refresh itself, but you use the menu fragment to access and see my follow requester, it will update. --> ASK TA during the lab. I don't think it is a big deal, and the main functionality deal with firebase goes well.

