### PR TITLE
Fix bugs

### DIFF
--- a/feelslikemonday/app/src/main/java/com/example/feelslikemonday/ui/moods/AddNewMoodActivity.java
+++ b/feelslikemonday/app/src/main/java/com/example/feelslikemonday/ui/moods/AddNewMoodActivity.java
@@ -144,6 +144,7 @@ public class AddNewMoodActivity extends AppCompatActivity {
             if (moodState == 1) {
                 byte[] imageByteArr = intent.getByteArrayExtra("image");
                 if(imageByteArr != null){
+                    moodBitmapByteArray = imageByteArr;
                     Bitmap imageBitmap = BitmapFactory.decodeByteArray(imageByteArr, 0, imageByteArr.length);
                     imageView.setImageBitmap(imageBitmap);
                 }
@@ -203,6 +204,7 @@ public class AddNewMoodActivity extends AppCompatActivity {
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(resultCode,resultCode,data);
         if (requestCode == AttachPhotoActivity.REQUEST_CODE && resultCode == AttachPhotoActivity.RES_OK && data != null) {
+            //get binary from activity result and set the image view to it.
             byte[] img = data.getByteArrayExtra(AttachPhotoActivity.BITMAP_BYTE_ARRAY_EXTRA);
             moodBitmapByteArray = img;
             byteArrayToBitmap(img);

--- a/feelslikemonday/app/src/main/java/com/example/feelslikemonday/ui/moods/AttachPhotoActivity.java
+++ b/feelslikemonday/app/src/main/java/com/example/feelslikemonday/ui/moods/AttachPhotoActivity.java
@@ -34,6 +34,10 @@ public class AttachPhotoActivity extends AppCompatActivity {
     //Extra codes
     public static final String BITMAP_BYTE_ARRAY_EXTRA = "BITMAP_STRING_EXTRA";
 
+    //Maximum dimensions of the downscaled bitmap
+    private final double MAX_DIM_SIZE = 350.0;
+
+
     private ImageView imageView;
     private Button cancelButton;
     private Context PostImage;
@@ -106,19 +110,29 @@ public class AttachPhotoActivity extends AppCompatActivity {
     }
 
     /**
-     * This converts bitmap to string. Code obtained from https://stackoverflow.com/questions/4989182/converting-java-bitmap-to-byte-array
+     * Down scale the bitmap so that it can fit into firestore
+     * @param srcBitmap
+     * @return
+     */
+    private Bitmap downscaleBitmap(Bitmap srcBitmap){
+        double maxSrcDim = Math.max(srcBitmap.getHeight(),srcBitmap.getWidth());
+        double scale = MAX_DIM_SIZE/maxSrcDim;
+        return Bitmap.createScaledBitmap(srcBitmap,(int)(srcBitmap.getWidth()/scale),(int)(srcBitmap.getHeight()/scale),false);
+    }
+
+    /**
+     * This converts bitmap to a byte array, which is used to store into firestore. Code obtained from https://stackoverflow.com/questions/4989182/converting-java-bitmap-to-byte-array
      * @param bitmap
      * This is a bitmap
      * @return
      *      return byte array string
      */
-    public byte[] bitmapToByteArray(Bitmap bitmap){
+    private byte[] bitmapToByteArray(Bitmap bitmap){
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
-        bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream);
+        bitmap.compress(Bitmap.CompressFormat.JPEG, 75, stream);
         byte[] byteArray = stream.toByteArray();
         return byteArray;
     }
-
 
     /**
      * This gives the requestCode you started it with, the resultCode it returned, and any additional data from it
@@ -148,6 +162,8 @@ public class AttachPhotoActivity extends AppCompatActivity {
                 final Bitmap selectedImage = BitmapFactory.decodeStream(imageStream);
                 //Copy bitmap to prevent recycling errors
                 returnBitmap = selectedImage.copy(selectedImage.getConfig(),selectedImage.isMutable());
+                //Downscale the image so that it fits in Firestore
+                returnBitmap = downscaleBitmap(returnBitmap);
                 imageView.setImageBitmap(returnBitmap);
 
             } catch (FileNotFoundException e) {


### PR DESCRIPTION
- Compress and downscale images to fit into firestore and retain quality
- Fix bug relating to the image resetting when editing a mood

Below is an example of a compressed image. If it is noticeable then I can make adjustments

![f13a9bf681fc72ae32f9e8d15f3e607f](https://user-images.githubusercontent.com/28885930/69500088-3dfbc100-0eb5-11ea-882e-6bf779e824aa.png)
![c9b68a0e67aa22d89f68255d6da70514](https://user-images.githubusercontent.com/28885930/69500089-405e1b00-0eb5-11ea-8fee-b449c3b101aa.png)
